### PR TITLE
Updated Doc2Vec model build and vectorizer 

### DIFF
--- a/altair/vectorize01/build/build_doc2vec_model.py
+++ b/altair/vectorize01/build/build_doc2vec_model.py
@@ -64,10 +64,14 @@ def main(script_folder, model_pickle_filename, training_algorithm, num_cores, ep
                 if len(code) == 0:
                     continue
                 else:
-                    tokenized_code = normalize_text(code, True, True, True, True)
+                    tokenized_code = normalize_text(code, remove_stop_words=False, only_letters=False, return_list=True)
                     doc2vec_tagged_documents.append(doc2vec.TaggedDocument(tokenized_code, [str(py_file)]))
 
     doc2vec_model = build_doc2vec_model(doc2vec_tagged_documents,training_algorithm,num_cores,epochs,vector_size,window)
+
+    # Per https://groups.google.com/forum/#!topic/gensim/w5RJiKh9x3A, model.docvecs can be discarded for inference only use
+    # However, initial testing did not have tangible impact on pickle size on model 
+    # doc2vec_model.docvecs = [] 
 
     logger.info("saving doc2vec model in a pickle file at %s" % model_pickle_filename)
     pickle.dump(doc2vec_model, open(model_pickle_filename, "wb"))
@@ -91,7 +95,7 @@ if __name__ == "__main__":
     parser.add_argument("--training_algorithm",
                         type=int,
                         default=2,
-                        help="Training algorithm is ‘distributed memory’ (PV-DM)=1 or distributed bag of words (PV-DBOW)=2 (default=2)")
+                        help="Training algorithm is 'distributed memory' (PV-DM)=1 or distributed bag of words (PV-DBOW)=2 (default=2)")
 
     parser.add_argument("--num_cores",
                         type=int,
@@ -111,7 +115,7 @@ if __name__ == "__main__":
     parser.add_argument("--window",
                         type=int,
                         default=5,
-                        help="Maximum distance between the predicted word and context words used for prediction within a document")
+                        help="Maximum distance between the predicted word and context words used for prediction within a document (default=5)")
 
     parser.add_argument("--max_script_count",
                         type=int,

--- a/altair/vectorize01/vectorizers/Doc2VecVectorizer.py
+++ b/altair/vectorize01/vectorizers/Doc2VecVectorizer.py
@@ -15,14 +15,18 @@ class Doc2VecVectorizer(Vectorizer):
         self.infer_kwargs = infer_kwargs
 
     def vectorize(self, document):
-        # Doc2Vec expects a list of words
-        normalized_doc = normalize_text(document, return_list=True, **self.normalizer_kwargs)
+        # Doc2Vec expects a list of words that includes stop words
+        normalized_doc = normalize_text(document, remove_stop_words=False, only_letters=False, return_list=True, **self.normalizer_kwargs)
+        # Doc2Vec requires a defined seed for deterministic results when calling infer_vector
+        self.model.random.seed(0)
         return self.model.infer_vector(normalized_doc, **self.infer_kwargs)
 
     def vectorize_multi(self, documents):
         vectorized = []
         for document in documents:
-            # Doc2Vec expects a list of words
-            normalized_doc = normalize_text(document, return_list=True, **self.normalizer_kwargs)
+            # Doc2Vec expects a list of words that includes stop words
+            normalized_doc = normalize_text(document, remove_stop_words=False, only_letters=False, return_list=True, **self.normalizer_kwargs)
+            # Doc2Vec requires a defined seed for deterministic results when calling infer_vector
+            self.model.random.seed(0)
             vectorized.append(self.model.infer_vector(normalized_doc, **self.infer_kwargs))
         return vectorized


### PR DESCRIPTION
- Doc2Vec model build now includes stop words, similar to how Word2Vec expects stop words
- Doc2Vec model build now retains numbers during normalization, which will allow vocabulary additions of words like 'word2vec' and 'doc2vec'
- Doc2Vec model build includes commented out line for erasing docvecs array to reduce model size before pickling but initial testing did not show tangible results. Leaving it in for future exploration
- Doc2Vec vectorizer now includes stop words and numbers during normalization to be consistent with model building
- Doc2Vec vectorizer now includes seed to obtain deterministic results for infer_vector method